### PR TITLE
fix calendar not showing in IE

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -83,4 +83,4 @@ You can also listen for these events:
 
 ## Unsupported Browsers
 
-* Internet Explorer <= 8
+* Internet Explorer <= 9

--- a/drcal.js
+++ b/drcal.js
@@ -19,13 +19,14 @@
   // Fire a custom event named "name" from element "element" with
   // extra data "data" attached to the details of the event.
   function customEvent(name, element, data) {
-    if (window.CustomEvent) {
-      var event = new CustomEvent(name, {detail: data});
-    } else {
-      var event = document.createEvent('CustomEvent');
-      event.initCustomEvent(name, true, true, data);
+    var evt;
+    try {
+      evt = new CustomEvent(name, {detail: data});
+    } catch(e) {
+      evt = document.createEvent('CustomEvent');
+      evt.initCustomEvent(name, true, true, data);
     }
-    element.dispatchEvent(event);
+    element.dispatchEvent(evt);
   }
 
   function pad(n) {


### PR DESCRIPTION
Good evening,
some friends reported that drcal is not working in latest IE.
After checking via netrenderer.com, i digged into the problem.

Well, here's the fix.
Miserably, i did not get IE 9 working as in https://github.com/krambuhl/custom-event-polyfill/blob/master/custom-event-polyfill.js suggested.