### PR TITLE
make calendar buttons more accessable

### DIFF
--- a/drcal.js
+++ b/drcal.js
@@ -68,8 +68,10 @@
 
     var prev = document.createElement('button');
     prev.className = 'prev';
+    prev.setAttribute('aria-label', 'Previous month');
     var next = document.createElement('button');
     next.className = 'next';
+    next.setAttribute('aria-label', 'Next month');
     var monthyear = document.createElement('span');
     monthyear.className = 'monthyear';
     var monthHeader = document.createElement('th');


### PR DESCRIPTION
Hi.
Just two minor additions to make month change buttons more accessable for people using screen readers.

Maybe there is a way to externalize the value in css to support different languages?

Cheers
midzer